### PR TITLE
Integer arithmetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+_tmp

--- a/pocket-calculator/Compiler.hs
+++ b/pocket-calculator/Compiler.hs
@@ -23,4 +23,6 @@ import VSM (Instruction(..), MemoryCell(..))
 compile :: Expr -> [MemoryCell]
 compile (Nbr n)     = [Op LIT, Val n]
 compile (Plus x y)  = compile x ++ compile y ++ [Op ADD]
+compile (Minus x y) = compile x ++ compile y ++ [Op SUB]
 compile (Times x y) = compile x ++ compile y ++ [Op MULT]
+compile (Over x y)  = compile x ++ compile y ++ [Op DIV]

--- a/pocket-calculator/VSM.hs
+++ b/pocket-calculator/VSM.hs
@@ -25,7 +25,9 @@ module VSM ( Instruction(..)
 -}
 data Instruction = LIT   -- put following (int) value on top of stack
                  | ADD   -- pop twice, add values and push result
+                 | SUB   -- pop twice, subtract values and push result
                  | MULT  -- pop twice, multiply values and push result
+                 | DIV   -- pop twice, (int) divide values and push result
     deriving Show
 
 {-
@@ -59,9 +61,11 @@ run :: [MemoryCell] -> Integer
 run = (\(StackMachine ds pgm) -> exec ds pgm) . newStackMachine
 
 exec :: DataStack -> ProgramMemory -> Integer
-exec ds       (Op LIT : Val x : pgm) = exec ( x      : ds) pgm
-exec (y:x:ds) (Op ADD         : pgm) = exec ((x + y) : ds) pgm
-exec (y:x:ds) (Op MULT        : pgm) = exec ((x * y) : ds) pgm
+exec ds       (Op LIT : Val x : pgm) = exec ( x       : ds) pgm
+exec (y:x:ds) (Op ADD         : pgm) = exec ((x + y)  : ds) pgm
+exec (y:x:ds) (Op SUB         : pgm) = exec ((x - y)  : ds) pgm
+exec (y:x:ds) (Op MULT        : pgm) = exec ((x * y)  : ds) pgm
+exec (y:x:ds) (Op DIV         : pgm) = exec (quot x y : ds) pgm
 exec (x:ds)   []                     = x
 exec _        _                      = error "kaboom!"
 --

--- a/pocket-calculator/Viz.hs
+++ b/pocket-calculator/Viz.hs
@@ -28,7 +28,9 @@ toString = showExpr 0
 showExpr :: Int -> Expr -> String
 showExpr indent (Nbr x)     = pad indent ++ show x ++ "\n"
 showExpr indent (Plus x y)  = showBranches "+" indent x y
+showExpr indent (Minus x y) = showBranches "-" indent x y
 showExpr indent (Times x y) = showBranches "*" indent x y
+showExpr indent (Over x y)  = showBranches "/" indent x y
 
 showBranches :: String -> Int -> Expr -> Expr -> String
 showBranches ctor indent x y = pad indent ++ ctor ++ "\n"


### PR DESCRIPTION
This PR extends our pocket calculator to make it support any integer arithmetic expression.

Now our arithmetic language lets us work with integer arithmetic expressions---a.k.a. arithmetic without fractions. Expressions involve sums, subtractions, products, and divisions among integer values. Since we're only dealing with integers, the result of evaluating an expression should still be an integer. For this reason, `x/y` is an integer division which returns the quotient `q` of Euclidean division of `x` by `y`---i.e. `x = y*q + r, 0 <= r < |y|`.

Notice how extending the `Expr` data type with more cases in the `Lang` module caused a ripple effect in all the others. This is an instance of the "expression problem" which is a bit too hard to solve with what we know at this stage. But we'll revisit this problem again in a few months from now and put in place a mind-bending solution :-)